### PR TITLE
Improve windows flashing script

### DIFF
--- a/sparse/boot/extracting-README.txt
+++ b/sparse/boot/extracting-README.txt
@@ -8,7 +8,8 @@ Step2: Extract the image
 
 = WINDOWS 7/8/10 =
 
-Right click the downloaded file and select Extract.
+Right click the downloaded file and select "Extract All..." then select directory
+where you want to extract the content and click Extract.
 
 = Linux =
 

--- a/sparse/boot/flashing-README.txt
+++ b/sparse/boot/flashing-README.txt
@@ -40,6 +40,7 @@ Next:
 * Next start the flashing script by double clicking the flash.bat file
   NOTE: Windows by default hides the .bat file so it might be shown just as flash file in 
         File explorer.
+  NOTE: If you see notification "Windows protected your PC", click "More info" and then "Run anyway"
 
 
 == LINUX ==


### PR DESCRIPTION
[flashing] Improve windows flashing script contributes to JB#39943

In some cases there are spaces in username and thus in the directory
path so to avoid that we need to get the filename from the full path.
Also the oem image is not included to the md5.lst file so we need to
skip md5sum checking for that file for now.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>