### PR TITLE
 [bluez5] Enable ofono HFP plugin. MER#1857

### DIFF
--- a/sparse/var/lib/environment/ofono/noplugin.conf
+++ b/sparse/var/lib/environment/ofono/noplugin.conf
@@ -1,7 +1,6 @@
 OFONO_ARGS=--noplugin=\
 ,he910\
 ,dun_gw_bluez5\
-,hfp_bluez5\
 ,cdma_provision\
 ,isimodem\
 ,n900\


### PR DESCRIPTION
This fix enables phone call with sailfishX via my car kit.
I tested it by editing the file on my xperia x. After a reboot phoning was possible via my car kit.
Credit s go to Adam Pigg as he pointed it out on sailfish dev list.
The same fix should be applied to jollaC droid config.