### PR TITLE
Add mce memnotify limits.

### DIFF
--- a/sparse/etc/mce/60-memnotify-f5121.conf
+++ b/sparse/etc/mce/60-memnotify-f5121.conf
@@ -1,0 +1,2 @@
+/system/osso/dsm/memnotify/warning/used=610000
+/system/osso/dsm/memnotify/critical/used=635000


### PR DESCRIPTION
Limits has been set so that warning is about 84% and critical about 88% of total memory.