### PR TITLE
Drop apkd-configs-home.

### DIFF
--- a/patterns/jolla-configuration-f5121.yaml
+++ b/patterns/jolla-configuration-f5121.yaml
@@ -15,7 +15,6 @@ Requires:
 - sd-utils
 - geoclue-provider-mlsdb
 - jolla-settings-system-flashlight
-- apkd-config-home
 - mapplauncherd-booster-silica-qt5-media
 
 Summary: Jolla Configuration f5121


### PR DESCRIPTION
[patterns] Drop apkd-configs-home. Fixes JB#40914

We do not need this as it will be installed later with android support.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>