### PR TITLE
Adjust peekfilter values.

### DIFF
--- a/sparse/etc/dconf/db/vendor.d/lipstick-configs.txt
+++ b/sparse/etc/dconf/db/vendor.d/lipstick-configs.txt
@@ -1,6 +1,10 @@
 [desktop/lipstick-jolla-home]
 reboot_warning_on_sim_remove=true
 
+[desktop/lipstick-jolla-home/peekfilter]
+boundaryWidth=48
+pressDelay=800
+
 [lipstick/screen/primary]
 physicalDotsPerInch=442.898
 width=1080


### PR DESCRIPTION
[config] Adjust peekfilter. Fixes JB#41192

Side gestures, e.g., minimizing apps are currently not always detected
which is what this commit tries to address.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>