### PR TITLE
[performance] Improve HWC performance. Contributes to JB#39389

### DIFF
--- a/sparse/var/lib/environment/compositor/droid-hal-device.conf
+++ b/sparse/var/lib/environment/compositor/droid-hal-device.conf
@@ -3,3 +3,7 @@ EGL_PLATFORM=hwcomposer
 QT_QPA_PLATFORM=hwcomposer
 # Determine which node is your touchscreen by checking /dev/input/event*
 LIPSTICK_OPTIONS=-plugin evdevtouch:/dev/touchscreen   -plugin evdevkeyboard:keymap=/usr/share/qt5/keymaps/droid.qmap
+
+QPA_HWC_IDLE_TIME=5
+QPA_HWC_BUFFER_COUNT=3
+


### PR DESCRIPTION
QPA_HWC_IDLE_TIME=5 will give the system more time to process other things,
like touch, sound... (It's approximately 1/3 of vsync).

QPA_HWC_BUFFER_COUNT=3 will make the qt5-qpa-hwcomposer-plugin use 3 buffers
instead of 2 (which is the default in surfaceflinger).

Signed-off-by: Franz-Josef Haider <franz.haider@jollamobile.com>