### PR TITLE
[f5121] Update submodule and remove 999-droid-system-bootdevice.rules. JB#41778

### DIFF
--- a/sparse/lib/udev/rules.d/999-droid-system-bootdevice.rules
+++ b/sparse/lib/udev/rules.d/999-droid-system-bootdevice.rules
@@ -1,1 +1,0 @@
-ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", IMPORT{program}="/bin/sh /lib/udev/platform-device $env{DEVPATH}", SYMLINK+="block/bootdevice/by-name/$env{ID_PART_ENTRY_NAME}"


### PR DESCRIPTION
This file is not required anymore, and if we don't remove it at the
same time as updating the droid-hal-configs submodule, errors would
occur during boot (non critical ones, but better to avoid them
entirely). Therefore this updates the submodule and removes the file.