### PR TITLE
[flashing] Update flashing script to include new flashing method and avoid using removed fastboot arguments. Fixes JB#42193, Fixes JB#41965.

### DIFF
--- a/kickstart/attachment/f5121
+++ b/kickstart/attachment/f5121
@@ -3,3 +3,4 @@
 droid-config-f5121-out-of-image-files
 droid-flashing-tools
 /etc/hw-release
+oem-flasher-f512x


### PR DESCRIPTION
Please double-check.

I have tested every case i could think of in both the windows and linux variants:

* no device
* 1 device
* 2 devices
* dis/connecting a different device while some partition is flashed

But i haven't tested every flavour of windows, linux and mac os.