### PR TITLE
Fix flashing script.

### DIFF
--- a/sparse/boot/flash.sh
+++ b/sparse/boot/flash.sh
@@ -106,7 +106,7 @@ for SERIALNO in $FASTBOOT_DEVICES; do
 
   if [ ! -z "$(echo $PRODUCT | grep -e "F512[12]")" ]; then
     SERIALNUMBERS="$SERIALNO $SERIALNUMBERS"
-    ((count++))
+    ((++count))
   fi
 done
 


### PR DESCRIPTION
Bash documentation says about '((':
Returns 1 if EXPRESSION evaluates to 0; returns 0 otherwise.

As the script calls set -e (exit on error) in the beginning, even though
this expression is valid it evaluates to non-zero and the script exits.

Using ((++count)) the expression evaluates to 0 and the script continues
correctly.

Signed-off-by: Juho Hämäläinen <juho.hamalainen@jolla.com>