### PR TITLE
[sensors] Enable pressure sensor. MER#1979

### DIFF
--- a/sparse/etc/sensord.conf.d/60-sensors-loire.conf
+++ b/sparse/etc/sensord.conf.d/60-sensors-loire.conf
@@ -1,0 +1,3 @@
+[plugins]
+pressureadaptor = hybrispressureadaptor
+

--- a/sparse/etc/xdg/QtProject/Sensors.conf
+++ b/sparse/etc/xdg/QtProject/Sensors.conf
@@ -1,0 +1,11 @@
+[Default]
+QAccelerometer=sensorfw.accelerometer
+QAmbientLightSensor=sensorfw.als
+QCompass=sensorfw.compass
+QMagnetometer=sensorfw.magnetometer
+QOrientationSensor=sensorfw.orientationsensor
+QProximitySensor=sensorfw.proximitysensor
+QRotationSensor=sensorfw.rotationsensor
+QLightSensor=sensorfw.lightsensor
+QGyroscope=sensorfw.gyroscope
+QPressureSensor=sensorfw.pressuresensor


### PR DESCRIPTION
Add needed sensor configurations to enable pressure sensor. Pressure sensor can be tested using the modified Messwerk app available at https://github.com/mlehtima/Messwerk (prebuilt at https://build.merproject.org/project/show/home:mal:apps)