### PR TITLE
rpm: fix local build

### DIFF
--- a/droid-config-common.inc
+++ b/droid-config-common.inc
@@ -14,6 +14,7 @@
 
 # Device-specific ofono configuration
 Provides: ofono-configs
+Obsoletes: ofono-configs-mer
 
 # Device-specific usb-moded configuration
 Provides: usb-moded-configs


### PR DESCRIPTION
Without "Obsoletes" ofono-configs-mer would not get uninstalled and
its contents would conflict.