### PR TITLE
patterns: Remove obsoleted sd-utils package.

### DIFF
--- a/patterns/jolla-configuration-f5121.yaml
+++ b/patterns/jolla-configuration-f5121.yaml
@@ -22,7 +22,6 @@ Requires:
 
 - sailfish-content-graphics-z@ICON_RES@
 - csd
-- sd-utils
 - geoclue-provider-mlsdb
 - jolla-settings-system-flashlight
 - mapplauncherd-booster-silica-qt5-media

--- a/patterns/jolla-configuration-f5122.yaml
+++ b/patterns/jolla-configuration-f5122.yaml
@@ -23,7 +23,6 @@ Requires:
 - jolla-settings-networking-multisim
 - sailfish-content-graphics-z@ICON_RES@
 - csd
-- sd-utils
 - geoclue-provider-mlsdb
 - jolla-settings-system-flashlight
 - mapplauncherd-booster-silica-qt5-media


### PR DESCRIPTION
[patterns] Remove obsoleted sd-utils package. JB#46513

The replacement for sd-utils is udisk2 and it is dependency for
patterns-sailfish-mw meta package.

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>