### PR TITLE
[f5121] Increase keyboard area peek filter boundary. Fixes JB#49003

### DIFF
--- a/sparse/etc/dconf/db/vendor.d/lipstick-configs.txt
+++ b/sparse/etc/dconf/db/vendor.d/lipstick-configs.txt
@@ -3,6 +3,7 @@ reboot_warning_on_sim_remove=true
 
 [desktop/lipstick-jolla-home/peekfilter]
 boundaryWidth=48
+keyboardBoundaryWidth=30
 pressDelay=800
 
 [lipstick/screen/primary]


### PR DESCRIPTION
With some pixels that don't react on touch, the default was too little
on this device.

@jpetrell 