### PR TITLE
Lookup operator names in MBPI

### DIFF
--- a/sparse/etc/ofono/ril_subscription.conf
+++ b/sparse/etc/ofono/ril_subscription.conf
@@ -1,4 +1,4 @@
-# This is a sample configuration file for Jolla ril driver
+# This is a configuration file for Jolla ril driver
 #
 # This file is expected to be installed in /etc/ofono
 #
@@ -12,133 +12,21 @@
 #
 
 [Settings]
-
-# This option stops RIL plugin from creating any RIL modems.
-# If it's set to true, all [ril_x] sections are ignored even
-# if they are present, and no default configurtation is created.
-#
-# Default is false
-#
-#EmptyConfig=false
-
-# If the phone has more than one SIM slot, the 3G/LTE module may be
-# shared by all modems, meaning that only one of the slots can use
-# 3G/LTE. In order to "hand 4G over" to the other slot, the modem
-# currently using 3G/LTE has to drop to GSM, release 3G/LTE module
-# and only then 3G/LTE can be used by the other modem. This setting
-# allows to disable this behaviour (say, if your phone has independent
-# 3G/LTE modules for each slot or you don't need 4G for both slots).
-# Obviously, it only has any effect if you have more than one SIM.
-#
-# Default is true (switch the current data modem to 2G when changing
-# the data modems)
-#
 #3GLTEHandover=true
+replaceStrangeOperatorNames=true
 
 [ril_0]
-
-# Required entry, defines the RIL socket path
 socket=/dev/socket/rild
-
-# Subscription string. Some (mostly, older) RILs require that 4 bytes
-# (usually SUB1 or SUB2) are written to the socket before rild starts
-# talking to us.
-#
-# Not sent by default.
-#
-#sub=SUB1
-
-# RIL logging prefix, to tell one socket from another in the log.
-# Makes sense if you have more than one modem configured.
-#
-# No prefix by default.
-#
 name=RIL1
 
-# Slot id for SET_UICC_SUBSCRIPTION request.
-#
-# By default the first modem becomes slot 0, the next one slot 1 and so on.
-#
+#sub=SUB1
 #slot=0
-
-# RIL request timeout, in milliseconds.
-#
-# The default is zero (no timeout)
-#
 #timeout=0
-
-# Setting this one to false would disable 4G technology selection.
-#
-# By default 4G is enabled
-#
 #enable4G=true
-
-# RIL_REQUEST_SET_UICC_SUBSCRIPTION is 115 in RIL version 9 (or earlier)
-# and 122 in RIL version 10 and later. Since ofono doesn't know in advance
-# which RIL version it's dealing with, it makes the decision at runtime.
-# Settings it to false disables the workaround and always sends 122.
-#
-# Default is true (select SET_UICC_SUBSCRIPTION based on the RIL version)
-#
 #uiccWorkaround=true
-
-# Points to the file containing comma-separated ECC (Emergency List Codes)
-# list, e.g. 911,112,*911,#911. The file is tracked by ofono and when its
-# contents changes, it's reflected in the EmergencyNumbers property of
-# org.ofono.VoiceCallManager.
-#
-# If necessary, the contents of the file can be synchronized with the
-# Android system property by adding something like this to /init.rc:
-#
-# on property:ril.ecclist=*
-#     write /var/lib/ofono/ril.ecclist ${ril.ecclist}
-#     chmod 0644 /var/lib/ofono/ril.ecclist
-#
 #ecclistFile=/var/lib/ofono/ril.ecclist
-
-# RIL_REQUEST_ALLOW_DATA may or may not be supported by your RIL.
-# This option allows you to forcibly enable or disable use of this request.
-# Possible values are auto, on and off
-#
-# Default is auto (usage based on the RIL version)
-#
 #allowDataReq=auto
-
-# Since RIL interface doesn't provide the standard way of querying the
-# number of pin retries left, some RIL implementation (namely Qualcomm)
-# allow to query the retry count by sending the empty pin. If your RIL
-# actually does check the empty pin (and decrements the retry count)
-# then you should turn this feature off.
-#
-# Default is true
-#
 #emptyPinQuery=true
-
-# Different RILs use different data call structures which don't necessarily
-# match the format specified in the data list header. The header may have
-# version 9 but the list may contain RIL_Data_Call_Response_v6 structures,
-# list version 10 may contain RIL_Data_Call_Response_v11 and so on. By default
-# ofono assumes that the version from the list header matches the contents
-# but sometimes you have to explicitly tell ofono which one to use.
-# Possible values are 6, 9, 11 and auto.
-#
-# Default is auto
-#
 #dataCallFormat=auto
-
-# Data call may fail with status 65535 which according to ril.h means that
-# we need to retry silently. The maximum number of retries is limited by
-# this parameter. Usually, one retry is enough. The first retry occurs
-# immediately, the subsequent ones after dataCallRetryDelay (see below)
-#
-# Default is 4
-#
 #dataCallRetryLimit=4
-
-# Delay between data call retries, in milliseconds. Note that the first
-# retry occurs immediately after the first failure, the delays are only
-# applied if the first retry fails too.
-#
-# Default is 200 ms
-#
 #dataCallRetryDelay=200


### PR DESCRIPTION
This sort of fixes the problem with all operators in the scan having the same name.